### PR TITLE
Correct installation instructions in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -451,7 +451,7 @@ day. :P
 
 == Install
 
-* sudo gem install rexical
+* sudo gem install oedipus_lex
 
 == License
 


### PR DESCRIPTION
Update the name of the gem to `oedipus_lex` and not `rexical` to be the right one for people following installation instructions from the README document.

Most of the time, people don't read, but just change it for the sake of consistency.

Cheers!

:heart: :heart: :heart: 
