### PR TITLE
Increase lineno on nil token

### DIFF
--- a/lib/oedipus_lex.rb
+++ b/lib/oedipus_lex.rb
@@ -316,13 +316,13 @@ class OedipusLex
 % starts.each do |s|
           <%= s %>
 % end
-% if option[:lineno] then
-          self.lineno += 1 if ss.peek(1) == "\n"
-% end
 
           token = nil
 
           until ss.eos? or token do
+% if option[:lineno] then
+            self.lineno += 1 if ss.peek(1) == "\n"
+% end
             token =
               case state
 % all_states.each do |the_states|

--- a/test/test_oedipus_lex.rb
+++ b/test/test_oedipus_lex.rb
@@ -741,4 +741,21 @@ class TestOedipusLex < Minitest::Test
 
     assert_lexer_error src, txt, "can not match (:B): 'a'"
   end
+
+  def test_incrementing_lineno_on_nil_token
+    src = <<-'REX'
+      class Calculator
+      option
+             lineno
+      rule
+             /\n/
+             /a/       { [:A, lineno] }
+      end
+    REX
+
+    txt = "\n\na"
+    exp = [[:A, 3]]
+
+    assert_lexer src, txt, exp
+  end
 end


### PR DESCRIPTION
Currently, when a rule doesn't generate a token, as it is often the case with whitespace, the line count isn't incremented properly. This patch solves this and comes with the corresponding test case.
