### PR TITLE
Use `skip` and `match?` instead of `scan` and `check`

### DIFF
--- a/test/test_oedipus_lex.rb
+++ b/test/test_oedipus_lex.rb
@@ -457,7 +457,7 @@ class TestOedipusLex < Minitest::Test
 
     ruby = generate_lexer src
 
-    assert_match "when ss.check(/\\d/) then", ruby
+    assert_match "when ss.match?(/\\d/) then", ruby
     assert_match "when text = ss.scan(/\\d+\\.\\d+/) then", ruby
     assert_match "when text = ss.scan(/\\d+/) then", ruby
     assert_match "end # group /\\d/", ruby
@@ -480,12 +480,12 @@ class TestOedipusLex < Minitest::Test
 
     ruby = generate_lexer src
 
-    assert_match "when ss.check(/\\d/) then", ruby
+    assert_match "when ss.match?(/\\d/) then", ruby
     assert_match "when text = ss.scan(/\\d+\\.\\d+/) then", ruby
     assert_match "when text = ss.scan(/\\d+/) then", ruby
     assert_match "end # group /\\d/", ruby
 
-    assert_match "when ss.check(/\\+/) then", ruby
+    assert_match "when ss.match?(/\\+/) then", ruby
     assert_match "when xx? && (text = ss.scan(/\\+whatever/)) then", ruby
     assert_match "when (state == :x) && (text = ss.scan(/\\+\\d+/)) then", ruby
     assert_match "end # group /\\d/", ruby


### PR DESCRIPTION
`skip` and `match?` return the length of the match or `nil` instead of the matched string. They can be used anywhere the result of the match is not used, to avoid allocating unused strings.

When scanning Redmine with Brakeman, I saw a 29% decrease in strings allocated by RubyParser. Most of these strings are pretty small, so the total allocated memory only decreased ~6%. Actual parsing times didn't seem to improve :sob:

What do you think?